### PR TITLE
Remove case of transition call (_get_children_nodes)

### DIFF
--- a/Source/Tree/tree_builder.lua
+++ b/Source/Tree/tree_builder.lua
@@ -178,11 +178,8 @@ end
 -- @local
 function PokerTreeBuilder:_get_children_nodes(parent_node)
 
-  --is this a transition call node (leading to a chance node)?
-  local call_is_transit = parent_node.current_player == constants.players.P2 and parent_node.bets[1] == parent_node.bets[2] and parent_node.street < constants.streets_count
-  
   local chance_node = parent_node.current_player == constants.players.chance
-  --transition call -> create a chance node
+  --terminal node has no children
   if parent_node.terminal then
     return {}
   --chance node


### PR DESCRIPTION
Signed-off-by: Karel Ha <mathemage@gmail.com>

- in response to [missing case of call_is_transit](https://gist.github.com/mathemage/041d738356030390875b519d0847bc97#file-tree_builder-lua-L194)